### PR TITLE
[#20] [FIX] 단일 파일 퀴즈 조회시 단어의 시작 인덱스 기준으로 정렬

### DIFF
--- a/src/main/java/com/mashup/munggoo/quiz/service/QuizService.java
+++ b/src/main/java/com/mashup/munggoo/quiz/service/QuizService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,6 +42,7 @@ public class QuizService {
             throw new NotFoundException("Quiz Does Not Generated.");
         }
 
+        quizzes.sort(Comparator.comparing(Quiz::getStartIndex));
         return quizRepository.saveAll(quizzes).stream().map(ResQuizDto::new).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
퀴즈 조회시 시작 인덱스 기준으로 정렬해 보내도록 했습니다